### PR TITLE
Update console_command_unmute.gml

### DIFF
--- a/Source/gg2/Scripts/DSM/Console/Built-InCommands/console_command_unmute.gml
+++ b/Source/gg2/Scripts/DSM/Console/Built-InCommands/console_command_unmute.gml
@@ -26,7 +26,7 @@ if !global.isHost{
 }
 //arctic a shit
 with(Player){
-    if ds_list_find_value(global.chatBanlist,socket_remote_ip(socket))!=-1{
+    if ds_list_find_index(global.chatBanlist,socket_remote_ip(socket))!=-1{
         hasChat=true
     }
 }


### PR DESCRIPTION
This is meant as a fix for the unmute command, which resulted in this upon executing (v2.2.1):
```
ERROR in
action number 1
of Begin Step Event
for object GameServer:

Error in code at line 29:
   
    if ds_list_find_value(global.chatBanlist,socket_remote_ip(socket))!=-1{
                                                                           ^
at position 74: Cannot compare arguments.
```

Fixes the main use case

Will provoke a crash for clients who don't have chat, but who have the same IP as another client who did have chat (and got muted), if any chat message is sent after unmuting